### PR TITLE
fix: `fw_mode` is not respected

### DIFF
--- a/etc/init.d/tailscale
+++ b/etc/init.d/tailscale
@@ -17,6 +17,7 @@ start_service() {
   config_get_bool std_err "settings" log_stderr 1
   config_get port "settings" port 41641
   config_get state_file "settings" state_file /etc/tailscale/tailscaled.state
+  config_get fw_mode "settings" fw_mode nftables
 
   /usr/bin/tailscaled --cleanup
 


### PR DESCRIPTION
没读取配置，导致后面的
```
procd_set_param env TS_DEBUG_FIREWALL_MODE="$fw_mode"
```

始终读取到空值。

后果：
对于 nft 机型（几乎所有的现代设备都是），大概率无法正确配置 IPv6 SubRoutes 信息
（ipv4 因为通常自带 iptables-nft 兼容命令行，能勉强配置成功）