### PR TITLE
feat: add build_feed.sh for self-built firmware + docs

### DIFF
--- a/build_scripts/build_feed.sh
+++ b/build_scripts/build_feed.sh
@@ -11,7 +11,7 @@
 #   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
 #
 #   # With a specific Go version:
-#   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale 1.26.5
+#   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale 1.26.6
 #
 #   # Only compile, no index:
 #   ./build_feed.sh /path/to/openwrt/buildroot --no-index
@@ -26,7 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 BUILDROOT="${1:-}"
 TAILSCALE_SRC="${2:-}"
-GO_VERSION="${3:-1.26.5}"
+GO_VERSION="${3:-1.26.6}"
 BUILD_INDEX="true"
 FEED_NAME="openwrt_tailscale"
 REPO_URL="https://github.com/GuNanOvO/openwrt-tailscale.git"

--- a/build_scripts/build_feed.sh
+++ b/build_scripts/build_feed.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# Build this repository's tailscale package inside an OpenWrt buildroot via a custom feed.
+# The package keeps the official name `tailscale`, so the buildroot's stale official
+# tailscale (e.g. from a frozen openwrt/packages branch) is replaced instead of duplicated.
+#
+# Usage:
+#   # Remote mode (GitHub feed, recommended for firmware builds):
+#   ./build_feed.sh /path/to/openwrt/buildroot
+#
+#   # Local mode (development, points the feed at a local checkout):
+#   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
+#
+#   # With a specific Go version:
+#   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale 1.26.5
+#
+#   # Only compile, no index:
+#   ./build_feed.sh /path/to/openwrt/buildroot --no-index
+#
+# The script is idempotent: re-running it after `./scripts/feeds update -a` re-removes
+# the official tailscale and rebuilds this repository's version, so the override
+# survives feed refreshes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+BUILDROOT="${1:-}"
+TAILSCALE_SRC="${2:-}"
+GO_VERSION="${3:-1.26.5}"
+BUILD_INDEX="true"
+FEED_NAME="openwrt_tailscale"
+REPO_URL="https://github.com/GuNanOvO/openwrt-tailscale.git"
+TARGET_ARCH=""
+
+# -- Parse options --
+for arg in "$@"; do
+    case "$arg" in
+        --no-index) BUILD_INDEX="false" ;;
+        --help|-h)
+            head -30 "$0"
+            exit 0
+            ;;
+    esac
+done
+
+if [ -z "$BUILDROOT" ] || [ ! -d "$BUILDROOT" ]; then
+    echo "Error: OpenWrt buildroot directory required"
+    echo "Usage: $0 /path/to/openwrt/buildroot [/path/to/openwrt-tailscale] [go_version] [--no-index]"
+    exit 1
+fi
+
+cd "$BUILDROOT"
+
+echo "=== OpenWrt Buildroot: $BUILDROOT ==="
+
+# -- Step 1: Prepare Go toolchain --
+# Override the buildroot's Go with a recent upstream release, otherwise newer
+# Tailscale sources fail with "go.mod requires go >= ...".
+echo ""
+echo "[Step 1] Preparing Go ${GO_VERSION} toolchain..."
+bash "${SCRIPT_DIR}/prepare_go_for_openwrt.sh" "$BUILDROOT" "$GO_VERSION"
+
+# -- Step 2: Set up custom feed --
+echo ""
+echo "[Step 2] Setting up custom feed: $FEED_NAME"
+
+FEEDS_CONF="feeds.conf.default"
+if [ -f "$FEEDS_CONF" ]; then
+    cp "$FEEDS_CONF" "${FEEDS_CONF}.bak.$(date +%s)" 2>/dev/null || true
+fi
+
+# Remove any previous entry of our feed so re-runs stay clean
+if [ -f "$FEEDS_CONF" ]; then
+    sed -i "/^src-\(git\|link\) ${FEED_NAME} /d" "$FEEDS_CONF"
+fi
+
+if [ -n "$TAILSCALE_SRC" ] && [ -d "$TAILSCALE_SRC" ]; then
+    echo "  Using local source: $TAILSCALE_SRC"
+    echo "src-link ${FEED_NAME} ${TAILSCALE_SRC}" >> "$FEEDS_CONF"
+else
+    echo "  Using remote source: ${REPO_URL}"
+    echo "src-git ${FEED_NAME} ${REPO_URL}" >> "$FEEDS_CONF"
+fi
+
+grep "^src-" "$FEEDS_CONF" | grep "$FEED_NAME" || true
+
+# -- Step 3: Update the feed and install the package --
+echo ""
+echo "[Step 3] Updating feeds..."
+
+rm -rf "feeds/${FEED_NAME}" 2>/dev/null || true
+./scripts/feeds update "$FEED_NAME"
+./scripts/feeds install -p "$FEED_NAME"
+
+PKG_LINK="package/feeds/${FEED_NAME}/tailscale"
+if [ ! -d "$PKG_LINK" ]; then
+    echo "Error: Feed package not found at ${PKG_LINK}"
+    find package/feeds/ -maxdepth 3 -name "Makefile" -path "*tailscale*" 2>/dev/null || true
+    exit 1
+fi
+echo "  Package installed at: ${PKG_LINK}"
+
+# -- Step 4: Remove the official tailscale from other feeds --
+# The official packages feed (often frozen on release branches like 24.10) ships an
+# old tailscale. Keeping its link around makes the build resolve the wrong Makefile.
+# This runs on every invocation so it also covers re-runs after `feeds update -a`.
+echo ""
+echo "[Step 4] Removing official tailscale from other feeds..."
+if [ -d package/feeds/packages/tailscale ]; then
+    rm -rf package/feeds/packages/tailscale
+    echo "  Removed package/feeds/packages/tailscale"
+else
+    echo "  No package/feeds/packages/tailscale found, nothing to do"
+fi
+
+# -- Step 5: Select the package in .config --
+echo ""
+echo "[Step 5] Selecting tailscale package..."
+
+sed -i '/^CONFIG_PACKAGE_tailscale=/d' .config 2>/dev/null || true
+echo "CONFIG_PACKAGE_tailscale=y" >> .config
+make defconfig > /dev/null 2>&1
+
+if grep -q '^CONFIG_PACKAGE_tailscale=y' .config 2>/dev/null; then
+    echo "  tailscale selected in config"
+else
+    echo "  tailscale NOT in config, run: make menuconfig"
+    exit 1
+fi
+
+# -- Step 6: Compile --
+echo ""
+echo "[Step 6] Compiling tailscale..."
+
+make "$PKG_LINK"/clean 2>/dev/null || true
+make "$PKG_LINK"/compile -j$(nproc) V=s
+
+# -- Step 7: Verify build output --
+echo ""
+echo "[Step 7] Verifying build output..."
+
+IPK_FILE=$(find bin/ -name "tailscale_*.ipk" -o -name "tailscale_*.apk" 2>/dev/null | head -1)
+if [ -n "$IPK_FILE" ]; then
+    echo "  Package generated: $IPK_FILE"
+    ls -lh "$IPK_FILE"
+else
+    echo "Error: No package file generated!"
+    find bin/ -name "tailscale*" 2>/dev/null || echo "  No tailscale files in bin/"
+    exit 1
+fi
+
+# -- Step 8: Generate index (optional) --
+if [ "$BUILD_INDEX" = "true" ]; then
+    echo ""
+    echo "[Step 8] Generating package index..."
+
+    make package/index V=s || echo "  Warning: package index generation failed (not fatal)"
+
+    INDEX_DIR="bin/packages/${TARGET_ARCH}/base"
+    if [ -z "$TARGET_ARCH" ]; then
+        INDEX_DIR=$(find bin/packages -name Packages 2>/dev/null | head -1 | xargs dirname 2>/dev/null || true)
+    fi
+    if [ -n "$INDEX_DIR" ] && [ -f "$INDEX_DIR/Packages" ]; then
+        if grep -q "^Package: tailscale$" "$INDEX_DIR/Packages"; then
+            echo "  tailscale found in Packages index"
+        else
+            echo "  Warning: tailscale not found in Packages index"
+        fi
+    fi
+else
+    echo ""
+    echo "[Step 8] Skipped index generation (--no-index)"
+fi
+
+# -- Done --
+echo ""
+echo "================================================"
+echo " tailscale build completed!"
+echo "================================================"
+echo ""
+echo "Package: $IPK_FILE"
+echo ""
+if echo "$IPK_FILE" | grep -q "\.ipk$"; then
+    echo "To install on device:  opkg install $IPK_FILE"
+elif echo "$IPK_FILE" | grep -q "\.apk$"; then
+    echo "To install on device:  apk add --allow-untrusted $IPK_FILE"
+fi
+echo ""
+echo "To build the full firmware with tailscale embedded:"
+echo "  make -j$(nproc) V=s"

--- a/docs/en/build/index.md
+++ b/docs/en/build/index.md
@@ -23,6 +23,7 @@ The build system uses:
 | `build_scripts/build_ipk.sh` | Build IPK packages (OpenWrt 24.10) |
 | `build_scripts/build_apk.sh` | Build APK packages (OpenWrt 25.12+) |
 | `build_scripts/prepare_go_for_openwrt.sh` | Prepare Go toolchain for OpenWrt SDK |
+| `build_scripts/build_feed.sh` | One-shot script to build this package inside a self-built firmware buildroot (as a custom feed) |
 
 ## CI/CD Pipeline
 

--- a/docs/en/reference/faq.md
+++ b/docs/en/reference/faq.md
@@ -39,6 +39,16 @@ Yes! Install [luci-app-tailscale-community](https://github.com/Tokisaki-Galaxy/l
 
 Yes! See the [Build Guide](/en/build/) for Docker-based build instructions.
 
+### How to embed the latest Tailscale into a self-built firmware?
+
+If you compile your own OpenWrt firmware and the official `packages` feed only ships an old tailscale, run the one-shot script from this repo. It replaces the buildroot's Go toolchain, adds this repo as a custom feed, and removes the stale official tailscale:
+
+```sh
+bash /path/to/openwrt-tailscale/build_scripts/build_feed.sh /path/to/openwrt/buildroot
+```
+
+Then build the full firmware (`make -j$(nproc) V=s`). See `package/tailscale/FORK.md` for details.
+
 ### Does UPX affect performance?
 
 UPX decompresses the binary at startup. The decompression is very fast (milliseconds) and the binary runs at native speed afterward. The memory overhead of decompression is negligible.

--- a/docs/zh/build/index.md
+++ b/docs/zh/build/index.md
@@ -23,6 +23,7 @@ description: 自行构建精简版 Tailscale 软件包 — 构建系统、脚本
 | `build_scripts/build_ipk.sh` | 构建 IPK 包 (OpenWrt 24.10) |
 | `build_scripts/build_apk.sh` | 构建 APK 包 (OpenWrt 25.12+) |
 | `build_scripts/prepare_go_for_openwrt.sh` | 为 OpenWrt SDK 准备 Go 工具链 |
+| `build_scripts/build_feed.sh` | 在自编译固件的 buildroot 中一键构建本包（以自定义 feed 方式） |
 
 ## CI/CD 流水线
 

--- a/docs/zh/reference/faq.md
+++ b/docs/zh/reference/faq.md
@@ -35,6 +35,16 @@ opkg update && opkg upgrade tailscale
 
 ## 构建
 
+### 如何将最新版 Tailscale 编入自编译固件？
+
+如果你自己编译 OpenWrt 固件，且官方 `packages` feed 只提供旧版 tailscale，可以运行本仓库的一键脚本（自动替换 buildroot 的 Go 工具链、添加本仓库为自定义 feed、移除官方旧 tailscale）：
+
+```sh
+bash /path/to/openwrt-tailscale/build_scripts/build_feed.sh /path/to/openwrt/buildroot
+```
+
+然后全量编译固件即可。详见 `package/tailscale/FORK.md`。
+
 ### UPX 影响性能吗？
 
 UPX 在启动时解压二进制。解压非常快（毫秒级），之后以原生速度运行。内存开销可以忽略。

--- a/package/tailscale/FORK.md
+++ b/package/tailscale/FORK.md
@@ -73,7 +73,7 @@ cp -r /tmp/openwrt-tailscale/package/tailscale ./package/tailscale/
 步骤一：在 buildroot 根目录执行下面的脚本，用上游 Go 版本覆盖当前的 Go 工具链：
 
 ```bash
-bash build_scripts/prepare_go_for_openwrt.sh /path/to/openwrt/buildroot 1.26.5
+bash build_scripts/prepare_go_for_openwrt.sh /path/to/openwrt/buildroot 1.26.6
 ```
 
 步骤二：在菜单中选中 tailscale 包（或者直接写入 `.config`）：
@@ -101,14 +101,14 @@ make -j$(nproc) V=s
 如果你只想要编译出 `.ipk` 包（而非完整固件），则执行：
 
 ```bash
-bash build_scripts/prepare_go_for_openwrt.sh /path/to/openwrt/buildroot 1.26.5
+bash build_scripts/prepare_go_for_openwrt.sh /path/to/openwrt/buildroot 1.26.6
 make package/tailscale/compile -j$(nproc) V=s
 ```
 
 如果你使用的是非 amd64 主机，也可以显式指定 `GO_ARCH`：
 
 ```bash
-GO_ARCH=arm64 bash build_scripts/prepare_go_for_openwrt.sh /path/to/openwrt/buildroot 1.26.5
+GO_ARCH=arm64 bash build_scripts/prepare_go_for_openwrt.sh /path/to/openwrt/buildroot 1.26.6
 ```
 
 ---

--- a/package/tailscale/FORK.md
+++ b/package/tailscale/FORK.md
@@ -16,7 +16,23 @@ Some users fork the `package` directory from this repository and build it using 
 
 ### 准备工作：把本包加入你的 buildroot
 
-**方法 A：添加为 feed（推荐）**
+**方法 A：一键脚本（推荐）**
+
+直接运行本仓库提供的 `build_feed.sh`：
+
+```bash
+# 远程模式（从 GitHub 拉取本仓库最新代码）
+bash /path/to/openwrt-tailscale/build_scripts/build_feed.sh /path/to/openwrt/buildroot
+
+# 本地模式（调试用，指向本地仓库副本）
+bash /path/to/openwrt-tailscale/build_scripts/build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
+```
+
+脚本会自动完成：替换 Go 工具链 → 添加本仓库为 feed → 移除其他 feed（如官方 `packages` feed）中的旧 tailscale → 选中并编译。脚本可重复执行；执行 `./scripts/feeds update -a` 后官方旧包会复活，重跑一次脚本即可。
+
+> **为什么保留包名 `tailscale`**：本仓库的定位是"再打包分发"（发布预编译 ipk/apk 供安装），包名即升级标识，改名会导致现有用户无法通过 `opkg upgrade tailscale` 升级。自编译固件时，脚本通过移除官方旧包来实现"替换"，无需改名。
+
+**方法 B：添加为 feed（手动）**
 
 编辑 `feeds.conf.default`，加入一行：
 
@@ -28,12 +44,18 @@ src-git openwrt_tailscale https://github.com/GuNanOvO/openwrt-tailscale.git
 
 ```bash
 ./scripts/feeds update openwrt_tailscale
-./scripts/feeds install tailscale
+./scripts/feeds install -p openwrt_tailscale tailscale
 ```
 
 之后本包的 Makefile 会出现在 `package/feeds/openwrt_tailscale/tailscale/`。
 
-**方法 B：手动复制**
+> **注意**：如果 buildroot 的其他 feed（如官方 `packages` feed）里也提供了 `tailscale` 包，同名包会互相覆盖，可能导致编到旧版本。出现这种情况时，移除其他 feed 中的旧包：
+
+```bash
+rm -rf package/feeds/packages/tailscale
+```
+
+**方法 C：手动复制**
 
 ```bash
 # 先克隆本仓库


### PR DESCRIPTION
## 概要

针对 #142（自编译固件时嵌入最新 tailscale）提供可重复的一键脚本，**保留包名 `tailscale`**。

### 变更内容

- **`build_scripts/build_feed.sh`**（新增）：一键在 OpenWrt buildroot 中构建本包
  - 替换 buildroot 旧 Go 工具链（默认 Go 1.26.6，满足 Tailscale 1.102.3 要求）
  - 添加本仓库为 src-git/src-link feed（指向 GuNanOvO 仓库）
  - 幂等移除官方 packages feed 中的旧 tailscale（`rm -rf package/feeds/packages/tailscale`），可重复执行，解决 `feeds update` 后旧包复活问题
- **`package/tailscale/FORK.md`**：新增"一键脚本"小节，整理手动 feed / 复制方式
- **docs（en/zh build 概览 + FAQ）**：新增 `build_feed.sh` 说明与自编译固件问答

### 为什么不改包名

本仓库定位是"再打包分发"，包名即升级标识；改名为 `tailscale-upx` 会破坏现有用户 `opkg upgrade tailscale` 升级路径（文件路径冲突需手动卸载重装）。因此用"移除官方旧包 + feed"方式实现替换。

### 相关

- Closes/参考: #142
- 背景：PR #154 曾尝试改包名，存在 GO_PKG_TAGS 截断、指向 fork URL 等问题，本方案取其 feed 化思路但不改包名。