### PR TITLE
fix(build_feed): use feeds install -a -p to actually install the feed

### DIFF
--- a/build_scripts/build_feed.sh
+++ b/build_scripts/build_feed.sh
@@ -105,7 +105,10 @@ echo "[Step 3] Updating feeds..."
 
 rm -rf "feeds/${FEED_NAME}" 2>/dev/null || true
 ./scripts/feeds update "$FEED_NAME"
-./scripts/feeds install -p "$FEED_NAME"
+# -a is required: bare `feeds install -p <feed>` only marks the feed as
+# preferred and installs nothing (silently), which leaves no symlink under
+# package/feeds/<feed>/. See scripts/feeds install() in OpenWrt 24.10.
+./scripts/feeds install -a -p "$FEED_NAME"
 
 PKG_LINK="package/feeds/${FEED_NAME}/tailscale"
 if [ ! -d "$PKG_LINK" ]; then


### PR DESCRIPTION
## 概要

修复 #142 中 Potterli20 实测反馈的第二个问题：脚本在 `feeds update` 成功后报 `Error: Feed package not found at package/feeds/openwrt_tailscale/tailscale`。

### 根因

OpenWrt 24.10 的 `scripts/feeds install` 中，`-p <feed>` 仅表示"优先使用该 feed"，**不带 `-a` 且无包名参数时什么都不安装**（静默返回 0）。因此不会生成 `package/feeds/openwrt_tailscale/tailscale` 符号链接。

### 修复

```diff
-./scripts/feeds install -p "$FEED_NAME"
+./scripts/feeds install -a -p "$FEED_NAME"
```

（`-a -p <feed>` 只安装该 feed 的全部包，不会动其他 feed。）

### 相关

- 参考: #142
- 前序: #156（curl|bash 支持，已合并）