### PR TITLE
Refactor build_feed.sh for better argument handling

### DIFF
--- a/build_scripts/build_feed.sh
+++ b/build_scripts/build_feed.sh
@@ -10,9 +10,10 @@
 #   # Local mode (development, points the feed at a local checkout):
 #   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
 #
-#   # With a specific Go version (positional or flag):
+#   # With a specific Go version (positional, flag or env):
 #   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale 1.26.6
 #   ./build_feed.sh /path/to/openwrt/buildroot --go-version 1.26.6
+#   GO_VERSION=1.26.6 ./build_feed.sh /path/to/openwrt/buildroot
 #
 #   # Only compile, no index:
 #   ./build_feed.sh /path/to/openwrt/buildroot --no-index
@@ -25,14 +26,19 @@
 #
 # Options:
 #   --no-index           Skip 'make package/index'
-#   --no-compile         Skip compiling; only set up the feed and select the
-#                        package in .config (implies --no-index)
-#   --go-version <ver>   Go toolchain version to install (default: 1.26.6)
+#   --no-compile         Skip compiling; only set up the feed and select it in
+#                        .config (implies --no-index)
+#   --go-version <ver>   Pin a Go toolchain version; by default the latest
+#                        stable release is auto-detected from golang.google.cn
+#                        (fallback: go.dev), with 1.26.6 as the offline fallback
 #   -h, --help           Show help
 #
 # Environment overrides:
 #   REPO_URL             Git URL used in remote mode (useful for mirrors)
 #   JOBS                 Parallel build jobs (default: nproc)
+#   GO_VERSION           Pin a Go version (same as --go-version)
+#   GO_VERSION_API       URL queried for the latest Go version
+#                        (default: https://golang.google.cn/VERSION?m=text)
 #
 # The script is idempotent: re-running it after `./scripts/feeds update -a` re-removes
 # the official tailscale and rebuilds this repository's version, so the override
@@ -52,7 +58,14 @@ REPO_NAME="openwrt-tailscale"
 JOBS="${JOBS:-$(nproc)}"
 BUILD_INDEX="true"
 BUILD_PACKAGE="true"
-GO_VERSION=""
+GO_VERSION="${GO_VERSION:-}"
+# Latest-version endpoints, tried in order. golang.google.cn first: it is the
+# official Google mirror reachable from mainland China without a proxy; go.dev
+# is the international fallback. Both return "goX.Y.Z" on the first line.
+GO_VERSION_APIS=(
+    "${GO_VERSION_API:-https://golang.google.cn/VERSION?m=text}"
+    "https://go.dev/VERSION?m=text"
+)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)"
 
@@ -60,6 +73,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)"
 
 warn() { printf '  [!] %s\n' "$*" >&2; }
 die()  { printf 'Error: %s\n' "$*" >&2; exit 1; }
+
+# Detect the latest stable Go version from the official endpoints.
+# Sets GO_VERSION_DETECTED and GO_VERSION_SOURCE on success; returns non-zero
+# when every endpoint fails or replies with something that does not parse as a
+# version (never trust arbitrary remote content blindly).
+detect_latest_go_version() {
+    local api out ver
+    for api in "${GO_VERSION_APIS[@]}"; do
+        out="$(curl -fsSL --max-time 15 "$api" 2>/dev/null || true)"
+        [ -n "$out" ] || continue
+        ver="${out%%$'\n'*}"        # first line only
+        ver="${ver//[[:space:]]/}"  # strip any whitespace
+        if [[ "$ver" =~ ^go([0-9]+(\.[0-9]+)*)$ ]]; then
+            GO_VERSION_DETECTED="${BASH_REMATCH[1]}"
+            GO_VERSION_SOURCE="$api"
+            return 0
+        fi
+        warn "unrecognized version reply from ${api}: ${ver:0:40}"
+    done
+    return 1
+}
 
 usage() {
     cat <<'EOF'
@@ -72,18 +106,23 @@ Arguments:
   buildroot              OpenWrt buildroot directory (required)
   source                 Local openwrt-tailscale checkout; omit it to use the
                          remote GitHub feed (or $REPO_URL)
-  go_version             Go toolchain version (default: 1.26.6)
+  go_version             Pin a Go toolchain version; by default the latest
+                         stable release is auto-detected from golang.google.cn
+                         (fallback: go.dev)
 
 Options:
   --no-index             Skip 'make package/index'
   --no-compile           Skip compiling; only set up the feed and select the
                          package in .config (implies --no-index)
-  --go-version <ver>     Same as the positional go_version argument
+  --go-version <ver>     Pin the Go toolchain version
   -h, --help             Show this help
 
 Environment:
   REPO_URL               Git URL for remote mode (e.g. a mirror)
   JOBS                   Parallel jobs for make (default: nproc)
+  GO_VERSION             Pin a Go version (same as --go-version)
+  GO_VERSION_API         URL queried for the latest Go version
+                         (default: https://golang.google.cn/VERSION?m=text)
 EOF
 }
 
@@ -116,8 +155,14 @@ done
 
 BUILDROOT="${POSITIONAL[0]:-}"
 TAILSCALE_SRC="${POSITIONAL[1]:-}"
-if [ -z "$GO_VERSION" ]; then
-    GO_VERSION="${POSITIONAL[2]:-$DEFAULT_GO_VERSION}"
+# Precedence: --go-version flag > GO_VERSION env > positional argument;
+# when none is given the latest stable version is auto-detected (Step 0).
+if [ -z "$GO_VERSION" ] && [ -n "${POSITIONAL[2]:-}" ]; then
+    GO_VERSION="${POSITIONAL[2]}"
+fi
+GO_VERSION_SPECIFIED="false"
+if [ -n "$GO_VERSION" ]; then
+    GO_VERSION_SPECIFIED="true"
 fi
 
 # --------------------------------------------------------------- validation ---
@@ -142,6 +187,23 @@ fi
 
 echo "=== OpenWrt Buildroot: $BUILDROOT ==="
 cd "$BUILDROOT"
+
+# -- Step 0: Resolve the Go version --
+if [ "$GO_VERSION_SPECIFIED" = "true" ]; then
+    echo ""
+    echo "[Step 0] Go version pinned by user: ${GO_VERSION}"
+else
+    echo ""
+    echo "[Step 0] Detecting latest Go version..."
+    if detect_latest_go_version; then
+        GO_VERSION="$GO_VERSION_DETECTED"
+        echo "  Latest stable Go: ${GO_VERSION} (from ${GO_VERSION_SOURCE})"
+    else
+        GO_VERSION="$DEFAULT_GO_VERSION"
+        warn "could not detect the latest Go version (offline or endpoints changed);"
+        warn "falling back to pinned default ${GO_VERSION}. Use --go-version to pin one manually."
+    fi
+fi
 
 # -- Step 1: Prepare Go toolchain --
 # Override the buildroot's Go with a recent upstream release, otherwise newer

--- a/build_scripts/build_feed.sh
+++ b/build_scripts/build_feed.sh
@@ -10,68 +10,156 @@
 #   # Local mode (development, points the feed at a local checkout):
 #   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
 #
-#   # With a specific Go version:
+#   # With a specific Go version (positional or flag):
 #   ./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale 1.26.6
+#   ./build_feed.sh /path/to/openwrt/buildroot --go-version 1.26.6
 #
 #   # Only compile, no index:
 #   ./build_feed.sh /path/to/openwrt/buildroot --no-index
 #
+#   # Only set up the feed and select it in .config, no compile:
+#   ./build_feed.sh /path/to/openwrt/buildroot --no-compile
+#
 #   # One-line online usage (no local checkout needed):
 #   bash <(curl -fsSL https://raw.githubusercontent.com/GuNanOvO/openwrt-tailscale/main/build_scripts/build_feed.sh) /path/to/openwrt/buildroot
 #
+# Options:
+#   --no-index           Skip 'make package/index'
+#   --no-compile         Skip compiling; only set up the feed and select the
+#                        package in .config (implies --no-index)
+#   --go-version <ver>   Go toolchain version to install (default: 1.26.6)
+#   -h, --help           Show help
+#
+# Environment overrides:
+#   REPO_URL             Git URL used in remote mode (useful for mirrors)
+#   JOBS                 Parallel build jobs (default: nproc)
+#
 # The script is idempotent: re-running it after `./scripts/feeds update -a` re-removes
 # the official tailscale and rebuilds this repository's version, so the override
-# survives feed refreshes.
+# survives feed refreshes. Note that the official tailscale link is removed *before*
+# `feeds install`, because OpenWrt silently skips packages that are already installed
+# from another feed.
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# --------------------------------------------------------------- settings ---
 
-BUILDROOT="${1:-}"
-TAILSCALE_SRC="${2:-}"
-GO_VERSION="${3:-1.26.6}"
-BUILD_INDEX="true"
+DEFAULT_GO_VERSION="1.26.6"
 FEED_NAME="openwrt_tailscale"
-REPO_URL="https://github.com/GuNanOvO/openwrt-tailscale.git"
+REPO_URL="${REPO_URL:-https://github.com/GuNanOvO/openwrt-tailscale.git}"
 REPO_OWNER="GuNanOvO"
 REPO_NAME="openwrt-tailscale"
-TARGET_ARCH=""
+JOBS="${JOBS:-$(nproc)}"
+BUILD_INDEX="true"
+BUILD_PACKAGE="true"
+GO_VERSION=""
 
-# -- Parse options --
-for arg in "$@"; do
-    case "$arg" in
-        --no-index) BUILD_INDEX="false" ;;
-        --help|-h)
-            head -30 "$0"
-            exit 0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)"
+
+# --------------------------------------------------------------- helpers ----
+
+warn() { printf '  [!] %s\n' "$*" >&2; }
+die()  { printf 'Error: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    cat <<'EOF'
+Usage: build_feed.sh /path/to/openwrt/buildroot [/path/to/openwrt-tailscale] [go_version] [options]
+
+Builds the openwrt-tailscale package inside an OpenWrt buildroot via a custom feed
+named openwrt_tailscale, overriding the official packages-feed version.
+
+Arguments:
+  buildroot              OpenWrt buildroot directory (required)
+  source                 Local openwrt-tailscale checkout; omit it to use the
+                         remote GitHub feed (or $REPO_URL)
+  go_version             Go toolchain version (default: 1.26.6)
+
+Options:
+  --no-index             Skip 'make package/index'
+  --no-compile           Skip compiling; only set up the feed and select the
+                         package in .config (implies --no-index)
+  --go-version <ver>     Same as the positional go_version argument
+  -h, --help             Show this help
+
+Environment:
+  REPO_URL               Git URL for remote mode (e.g. a mirror)
+  JOBS                   Parallel jobs for make (default: nproc)
+EOF
+}
+
+# --------------------------------------------------------------- arg parse ---
+
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-index)
+            BUILD_INDEX="false"; shift ;;
+        --no-compile)
+            BUILD_PACKAGE="false"; BUILD_INDEX="false"; shift ;;
+        --go-version)
+            [ $# -ge 2 ] || die "--go-version requires a value"
+            GO_VERSION="$2"; shift 2 ;;
+        --go-version=*)
+            GO_VERSION="${1#--go-version=}"; shift ;;
+        -h|--help)
+            usage; exit 0 ;;
+        --)
+            shift
+            while [ $# -gt 0 ]; do POSITIONAL+=("$1"); shift; done
             ;;
+        -*)
+            die "unknown option: $1 (see --help)" ;;
+        *)
+            POSITIONAL+=("$1"); shift ;;
     esac
 done
 
-if [ -z "$BUILDROOT" ] || [ ! -d "$BUILDROOT" ]; then
-    echo "Error: OpenWrt buildroot directory required"
-    echo "Usage: $0 /path/to/openwrt/buildroot [/path/to/openwrt-tailscale] [go_version] [--no-index]"
-    exit 1
+BUILDROOT="${POSITIONAL[0]:-}"
+TAILSCALE_SRC="${POSITIONAL[1]:-}"
+if [ -z "$GO_VERSION" ]; then
+    GO_VERSION="${POSITIONAL[2]:-$DEFAULT_GO_VERSION}"
 fi
 
-cd "$BUILDROOT"
+# --------------------------------------------------------------- validation ---
+
+if [ -z "$BUILDROOT" ]; then
+    usage >&2
+    exit 1
+fi
+[ -d "$BUILDROOT" ] || die "OpenWrt buildroot directory not found: $BUILDROOT"
+BUILDROOT="$(cd "$BUILDROOT" && pwd)"
+if [ ! -f "$BUILDROOT/scripts/feeds" ] || [ ! -f "$BUILDROOT/Makefile" ]; then
+    die "$BUILDROOT does not look like an OpenWrt buildroot (scripts/feeds or Makefile missing)"
+fi
+[ -x "$BUILDROOT/scripts/feeds" ] || die "scripts/feeds is not executable; run: chmod +x $BUILDROOT/scripts/feeds"
+
+if [ -n "$TAILSCALE_SRC" ]; then
+    [ -d "$TAILSCALE_SRC" ] || die "local openwrt-tailscale source not found: $TAILSCALE_SRC"
+    # src-link entries are resolved relative to the buildroot by scripts/feeds,
+    # so always store an absolute path.
+    TAILSCALE_SRC="$(cd "$TAILSCALE_SRC" && pwd)"
+fi
 
 echo "=== OpenWrt Buildroot: $BUILDROOT ==="
+cd "$BUILDROOT"
 
 # -- Step 1: Prepare Go toolchain --
 # Override the buildroot's Go with a recent upstream release, otherwise newer
 # Tailscale sources fail with "go.mod requires go >= ...".
 echo ""
 echo "[Step 1] Preparing Go ${GO_VERSION} toolchain..."
-if [ -f "${SCRIPT_DIR}/prepare_go_for_openwrt.sh" ]; then
+if [ -n "$SCRIPT_DIR" ] && [ -f "${SCRIPT_DIR}/prepare_go_for_openwrt.sh" ]; then
     bash "${SCRIPT_DIR}/prepare_go_for_openwrt.sh" "$BUILDROOT" "$GO_VERSION"
 else
     # Fallback for curl|bash execution: the companion script is not on disk
     # (SCRIPT_DIR resolves to /dev/fd), download it into a temp dir instead.
     echo "  Companion script not found locally, downloading it..."
+    command -v curl > /dev/null 2>&1 || die "curl is required to download the companion script"
     PREPARE_TMP="$(mktemp -d)"
     trap 'rm -rf "$PREPARE_TMP"' EXIT
-    curl -fsSL "https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/build_scripts/prepare_go_for_openwrt.sh" -o "$PREPARE_TMP/prepare_go_for_openwrt.sh"
+    curl -fsSL "https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/build_scripts/prepare_go_for_openwrt.sh" \
+        -o "$PREPARE_TMP/prepare_go_for_openwrt.sh" \
+        || die "failed to download prepare_go_for_openwrt.sh"
     bash "$PREPARE_TMP/prepare_go_for_openwrt.sh" "$BUILDROOT" "$GO_VERSION"
 fi
 
@@ -79,17 +167,35 @@ fi
 echo ""
 echo "[Step 2] Setting up custom feed: $FEED_NAME"
 
-FEEDS_CONF="feeds.conf.default"
-if [ -f "$FEEDS_CONF" ]; then
-    cp "$FEEDS_CONF" "${FEEDS_CONF}.bak.$(date +%s)" 2>/dev/null || true
+# OpenWrt reads feeds.conf when it exists and then ignores feeds.conf.default
+# entirely (see parse_config() in scripts/feeds), so always edit the active file.
+if [ -f feeds.conf ]; then
+    FEEDS_CONF="feeds.conf"
+elif [ -f feeds.conf.default ]; then
+    FEEDS_CONF="feeds.conf.default"
+else
+    die "no feeds configuration found (feeds.conf / feeds.conf.default) in $BUILDROOT"
+fi
+echo "  Active feeds config: $FEEDS_CONF"
+
+if [ "$FEEDS_CONF" = "feeds.conf" ] \
+   && ! grep -qE '^[[:space:]]*src-' feeds.conf \
+   && grep -qE '^[[:space:]]*src-' feeds.conf.default 2> /dev/null; then
+    warn "feeds.conf exists but has no feed entries while feeds.conf.default does;"
+    warn "OpenWrt ignores feeds.conf.default in that case - other feeds will be missing."
 fi
 
-# Remove any previous entry of our feed so re-runs stay clean
-if [ -f "$FEEDS_CONF" ]; then
-    sed -i "/^src-\(git\|link\) ${FEED_NAME} /d" "$FEEDS_CONF"
+# Keep a single pristine backup so the original state can always be restored.
+if [ ! -f "${FEEDS_CONF}.bak" ]; then
+    cp "$FEEDS_CONF" "${FEEDS_CONF}.bak"
+    echo "  Backup saved: ${FEEDS_CONF}.bak"
 fi
 
-if [ -n "$TAILSCALE_SRC" ] && [ -d "$TAILSCALE_SRC" ]; then
+# Remove any previous entry of our feed so re-runs stay clean. The boundary
+# ([[:space:]]|$) avoids matching feeds whose name merely starts with ours.
+sed -i -E "/^[[:space:]]*src-[a-z]+[[:space:]]+${FEED_NAME}([[:space:]]|\$)/d" "$FEEDS_CONF"
+
+if [ -n "$TAILSCALE_SRC" ]; then
     echo "  Using local source: $TAILSCALE_SRC"
     echo "src-link ${FEED_NAME} ${TAILSCALE_SRC}" >> "$FEEDS_CONF"
 else
@@ -97,14 +203,52 @@ else
     echo "src-git ${FEED_NAME} ${REPO_URL}" >> "$FEEDS_CONF"
 fi
 
-grep "^src-" "$FEEDS_CONF" | grep "$FEED_NAME" || true
+FEED_LINES="$(grep -cE "^[[:space:]]*src-[a-z]+[[:space:]]+${FEED_NAME}([[:space:]]|\$)" "$FEEDS_CONF" || true)"
+if [ "$FEED_LINES" != "1" ]; then
+    die "expected exactly one '${FEED_NAME}' line in $FEEDS_CONF, found $FEED_LINES"
+fi
+grep -E "^[[:space:]]*src-[a-z]+[[:space:]]+${FEED_NAME}([[:space:]]|\$)" "$FEEDS_CONF"
 
-# -- Step 3: Update the feed and install the package --
+# -- Step 3: Update the feed --
 echo ""
 echo "[Step 3] Updating feeds..."
 
-rm -rf "feeds/${FEED_NAME}" 2>/dev/null || true
+# Force a clean checkout/relink so a stale or relocated source cannot survive silently.
+rm -rf "feeds/${FEED_NAME}"
 ./scripts/feeds update "$FEED_NAME"
+[ -d "feeds/${FEED_NAME}" ] || die "feed update did not produce feeds/${FEED_NAME}"
+
+# -- Step 4: Remove the official tailscale from other feeds --
+# The official packages feed (often frozen on release branches like 24.10) ships an
+# old tailscale. Keeping its link around makes the build resolve the wrong Makefile.
+# This must happen BEFORE 'feeds install' (Step 5): OpenWrt silently skips a package
+# that is already installed from another feed, which would leave no symlink under
+# package/feeds/<our feed>/ and break the build on the first run.
+# Running it on every invocation also keeps the override alive after 'feeds update -a'.
+echo ""
+echo "[Step 4] Removing official tailscale from other feeds..."
+REMOVED_CONFLICT="false"
+# 'tailscaled' is covered too: some feeds historically shipped it as a separate
+# package, and our package PROVIDES both names.
+for pkgname in tailscale tailscaled; do
+    for conflict in package/feeds/*/${pkgname}; do
+        [ -e "$conflict" ] || continue
+        case "$conflict" in
+            package/feeds/${FEED_NAME}/*) continue ;;
+        esac
+        rm -rf "$conflict"
+        echo "  Removed ${conflict}"
+        REMOVED_CONFLICT="true"
+    done
+done
+if [ "$REMOVED_CONFLICT" = "false" ]; then
+    echo "  No tailscale from other feeds found, nothing to do"
+fi
+
+# -- Step 5: Install the package from our feed --
+echo ""
+echo "[Step 5] Installing tailscale from feed ${FEED_NAME}..."
+
 # -a is required: bare `feeds install -p <feed>` only marks the feed as
 # preferred and installs nothing (silently), which leaves no symlink under
 # package/feeds/<feed>/. See scripts/feeds install() in OpenWrt 24.10.
@@ -112,82 +256,92 @@ rm -rf "feeds/${FEED_NAME}" 2>/dev/null || true
 
 PKG_LINK="package/feeds/${FEED_NAME}/tailscale"
 if [ ! -d "$PKG_LINK" ]; then
-    echo "Error: Feed package not found at ${PKG_LINK}"
-    find package/feeds/ -maxdepth 3 -name "Makefile" -path "*tailscale*" 2>/dev/null || true
+    echo "Error: Feed package not found at ${PKG_LINK}" >&2
+    find package/feeds/ -maxdepth 3 -name "Makefile" -path "*tailscale*" 2> /dev/null || true
     exit 1
 fi
 echo "  Package installed at: ${PKG_LINK}"
 
-# -- Step 4: Remove the official tailscale from other feeds --
-# The official packages feed (often frozen on release branches like 24.10) ships an
-# old tailscale. Keeping its link around makes the build resolve the wrong Makefile.
-# This runs on every invocation so it also covers re-runs after `feeds update -a`.
-echo ""
-echo "[Step 4] Removing official tailscale from other feeds..."
-if [ -d package/feeds/packages/tailscale ]; then
-    rm -rf package/feeds/packages/tailscale
-    echo "  Removed package/feeds/packages/tailscale"
-else
-    echo "  No package/feeds/packages/tailscale found, nothing to do"
-fi
+LINK_TARGET="$(readlink "$PKG_LINK" 2> /dev/null || true)"
+case "$LINK_TARGET" in
+    *feeds/${FEED_NAME}/*| "") : ;;
+    *) warn "unexpected symlink target for ${PKG_LINK}: ${LINK_TARGET}" ;;
+esac
 
-# -- Step 5: Select the package in .config --
+# -- Step 6: Select the package in .config --
 echo ""
-echo "[Step 5] Selecting tailscale package..."
+echo "[Step 6] Selecting tailscale package..."
 
-sed -i '/^CONFIG_PACKAGE_tailscale=/d' .config 2>/dev/null || true
+sed -i '/^CONFIG_PACKAGE_tailscale=/d' .config 2> /dev/null || true
 echo "CONFIG_PACKAGE_tailscale=y" >> .config
-make defconfig > /dev/null 2>&1
-
-if grep -q '^CONFIG_PACKAGE_tailscale=y' .config 2>/dev/null; then
+if ! make defconfig > /dev/null 2>&1; then
+    die "make defconfig failed; check the buildroot configuration"
+fi
+if grep -q '^CONFIG_PACKAGE_tailscale=y' .config 2> /dev/null; then
     echo "  tailscale selected in config"
 else
-    echo "  tailscale NOT in config, run: make menuconfig"
-    exit 1
+    die "tailscale is not in .config after defconfig; run 'make menuconfig' and check dependencies"
 fi
 
-# -- Step 6: Compile --
-echo ""
-echo "[Step 6] Compiling tailscale..."
+# -- Step 7: Compile (optional) --
+if [ "$BUILD_PACKAGE" = "true" ]; then
+    echo ""
+    echo "[Step 7] Compiling tailscale..."
 
-make "$PKG_LINK"/clean 2>/dev/null || true
-make "$PKG_LINK"/compile -j$(nproc) V=s
+    make "${PKG_LINK}/clean" > /dev/null 2>&1 || true
+    make "${PKG_LINK}/compile" -j"$JOBS" V=s || die "compiling tailscale failed"
 
-# -- Step 7: Verify build output --
-echo ""
-echo "[Step 7] Verifying build output..."
+    # -- Step 8: Verify build output --
+    echo ""
+    echo "[Step 8] Verifying build output..."
 
-IPK_FILE=$(find bin/ -name "tailscale_*.ipk" -o -name "tailscale_*.apk" 2>/dev/null | head -1)
-if [ -n "$IPK_FILE" ]; then
-    echo "  Package generated: $IPK_FILE"
-    ls -lh "$IPK_FILE"
+    # Pick the newest match: bin/ may still hold artifacts of the official tailscale
+    # from earlier builds. APK file names use dashes, IPK names use underscores.
+    IPK_FILE=""
+    if find bin/ -type f -printf '%T@ %p\n' >/dev/null 2>&1; then
+        IPK_FILE="$(find bin/ -type f \
+                \( -name 'tailscale_*.ipk' -o -name 'tailscale_*.apk' -o -name 'tailscale-*.apk' \) \
+                -printf '%T@ %p\n' 2> /dev/null \
+            | sort -rn | head -n 1 | cut -d' ' -f2- || true)"
+    else
+        # BSD/macOS find without -printf: fall back to -newer-based ordering or plain list
+        IPK_FILE="$(find bin/ -type f \
+                \( -name 'tailscale_*.ipk' -o -name 'tailscale_*.apk' -o -name 'tailscale-*.apk' \) \
+                2> /dev/null | head -n 1 || true)"
+    fi
+
+    if [ -n "$IPK_FILE" ] && [ -f "$IPK_FILE" ]; then
+        echo "  Package generated: $IPK_FILE"
+        ls -lh "$IPK_FILE"
+    else
+        echo "Error: No package file generated!" >&2
+        find bin/ -name 'tailscale*' 2> /dev/null || echo "  No tailscale files in bin/" >&2
+        exit 1
+    fi
 else
-    echo "Error: No package file generated!"
-    find bin/ -name "tailscale*" 2>/dev/null || echo "  No tailscale files in bin/"
-    exit 1
+    echo ""
+    echo "[Step 7] Skipped compilation (--no-compile)"
 fi
 
-# -- Step 8: Generate index (optional) --
+# -- Step 9: Generate index (optional) --
 if [ "$BUILD_INDEX" = "true" ]; then
     echo ""
-    echo "[Step 8] Generating package index..."
+    echo "[Step 9] Generating package index..."
 
-    make package/index V=s || echo "  Warning: package index generation failed (not fatal)"
+    make package/index V=s || warn "package index generation failed (not fatal)"
 
-    INDEX_DIR="bin/packages/${TARGET_ARCH}/base"
-    if [ -z "$TARGET_ARCH" ]; then
-        INDEX_DIR=$(find bin/packages -name Packages 2>/dev/null | head -1 | xargs dirname 2>/dev/null || true)
+    INDEX_FILE="$(find bin/packages -name Packages -type f 2> /dev/null | head -n 1 || true)"
+    if [ -n "$INDEX_FILE" ] && grep -q '^Package: tailscale$' "$INDEX_FILE"; then
+        echo "  tailscale found in Packages index (${INDEX_FILE})"
+    else
+        warn "tailscale not found in Packages index"
     fi
-    if [ -n "$INDEX_DIR" ] && [ -f "$INDEX_DIR/Packages" ]; then
-        if grep -q "^Package: tailscale$" "$INDEX_DIR/Packages"; then
-            echo "  tailscale found in Packages index"
-        else
-            echo "  Warning: tailscale not found in Packages index"
-        fi
-    fi
+elif [ "$BUILD_PACKAGE" = "true" ]; then
+    echo ""
+    echo "[Step 9] Skipped index generation (--no-index)"
 else
     echo ""
-    echo "[Step 8] Skipped index generation (--no-index)"
+    echo "[Step 9] Skipped index generation (--no-compile)"
 fi
 
 # -- Done --
@@ -196,13 +350,25 @@ echo "================================================"
 echo " tailscale build completed!"
 echo "================================================"
 echo ""
-echo "Package: $IPK_FILE"
-echo ""
-if echo "$IPK_FILE" | grep -q "\.ipk$"; then
-    echo "To install on device:  opkg install $IPK_FILE"
-elif echo "$IPK_FILE" | grep -q "\.apk$"; then
-    echo "To install on device:  apk add --allow-untrusted $IPK_FILE"
+if [ "$BUILD_PACKAGE" = "true" ]; then
+    echo "Package: $IPK_FILE"
+    echo ""
+    case "$IPK_FILE" in
+        *.ipk) echo "To install on device:  opkg install $IPK_FILE" ;;
+        *.apk) echo "To install on device:  apk add --allow-untrusted $IPK_FILE" ;;
+    esac
+    echo ""
+    echo "To build the full firmware with tailscale embedded:"
+    echo "  make -j$JOBS V=s"
+else
+    echo "Feed setup and package selection completed (compilation skipped)."
+    echo ""
+    echo "To compile the package now:"
+    echo "  make ${PKG_LINK}/compile -j$JOBS V=s"
+    echo ""
+    echo "To build the full firmware with tailscale embedded:"
+    echo "  make -j$JOBS V=s"
 fi
 echo ""
-echo "To build the full firmware with tailscale embedded:"
-echo "  make -j$(nproc) V=s"
+echo "NOTE: running './scripts/feeds update -a && ./scripts/feeds install -a' later"
+echo "      brings the official tailscale back - re-run this script to override it again."

--- a/build_scripts/prepare_go_for_openwrt.sh
+++ b/build_scripts/prepare_go_for_openwrt.sh
@@ -8,6 +8,12 @@
 #
 # Example:
 #   ./build_scripts/prepare_go_for_openwrt.sh /home/user/openwrt 1.26.3
+#
+# Environment:
+#   GO_OS / GO_ARCH   Host platform of the Go tarball (default: detected)
+#   GO_DL_BASE        Preferred download base URL
+#                     (default: https://golang.google.cn/dl, official China mirror;
+#                     https://go.dev/dl is always tried as fallback)
 
 set -euo pipefail
 
@@ -39,8 +45,14 @@ if [ -z "$GO_ARCH" ]; then
   esac
 fi
 
+# golang.google.cn first: official Google mirror, reachable from mainland China
+# without a proxy. go.dev is the international fallback and serves the same files.
+GO_DL_BASES=(
+  "${GO_DL_BASE:-https://golang.google.cn/dl}"
+  "https://go.dev/dl"
+)
+
 GO_TARBALL="go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
-GO_URL="https://go.dev/dl/${GO_TARBALL}"
 GO_INSTALL_DIR="$BUILDROOT_DIR/staging_dir/hostpkg/go"
 GO_BIN_DIR="$BUILDROOT_DIR/staging_dir/hostpkg/bin"
 GO_HOST_BIN_DIR="$BUILDROOT_DIR/staging_dir/host/bin"
@@ -51,8 +63,21 @@ mkdir -p "$DOWNLOAD_DIR" "$GO_BIN_DIR" "$GO_HOST_BIN_DIR" "$GO_CROSS_BIN_DIR"
 
 ARCHIVE_PATH="$DOWNLOAD_DIR/$GO_TARBALL"
 if [ ! -f "$ARCHIVE_PATH" ]; then
-  echo "Downloading Go ${GO_VERSION} from ${GO_URL}"
-  curl -fsSL -o "$ARCHIVE_PATH" "$GO_URL"
+  downloaded="false"
+  for base in "${GO_DL_BASES[@]}"; do
+    GO_URL="${base}/${GO_TARBALL}"
+    echo "Downloading Go ${GO_VERSION} from ${GO_URL}"
+    if curl -fsSL --retry 3 -o "$ARCHIVE_PATH" "$GO_URL"; then
+      downloaded="true"
+      break
+    fi
+    rm -f "$ARCHIVE_PATH"
+    echo "  Download from ${base} failed, trying next mirror..." >&2
+  done
+  if [ "$downloaded" != "true" ]; then
+    echo "Error: failed to download ${GO_TARBALL} from any mirror" >&2
+    exit 1
+  fi
 else
   echo "Using cached Go archive: $ARCHIVE_PATH"
 fi


### PR DESCRIPTION
# build_feed.sh

在 OpenWrt 编译环境（buildroot）中，通过自定义软件源（feed）编译本仓库的 Tailscale 软件包。

包名保持官方的 `tailscale`，因此脚本会**替换**（而非并存）buildroot 中过时的官方版本——例如 24.10 等冻结分支的 packages feed 自带的旧版。

## 特性

- **幂等可重跑**：`./scripts/feeds update -a` 把官方包带回后，重跑本脚本即可恢复覆盖
- **自动准备 Go 工具链**：自动获取最新稳定版 Go（跟随 golang.google.cn），避免 buildroot 自带 Go 过旧导致 `go.mod requires go >= ...`
- **自动移除官方包冲突**：在正确时机删除其他 feed 的官方 tailscale 链接，确保构建解析到本仓库的 Makefile
- **不依赖本地检出**：支持 `curl | bash` 一行式在线执行，配套脚本按需自动下载
- **可跳过编译**：`--no-compile` 只完成 feed 配置与勾选，编译时机自己控制

## 前置要求

- 有效的 OpenWrt buildroot（存在顶层 `Makefile`、可执行的 `scripts/feeds`、`feeds.conf` 或 `feeds.conf.default`）
- `curl`（在线下载 Go 工具链和配套脚本）
- 磁盘与网络：Go 工具链数百 MB 缓存，Tailscale 源码约 30 MB

## 用法

### 远程模式（推荐）

```bash
./build_feed.sh /path/to/openwrt/buildroot
```

把 GitHub 上的本仓库注册为 feed，执行全套流程（准备 Go → 配置 feed → 更新 → 安装 → 勾选 → 编译 → 校验 → 生成索引）。

### 本地开发模式

```bash
./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
```

第二个参数指向本地检出目录，feed 以 `src-link` 挂载。改完本地代码重跑即可，相对路径会自动转为绝对路径。

### Go 版本

默认**自动获取官方最新稳定版**：优先查询 `https://golang.google.cn/VERSION?m=text`（Google 官方中国镜像，国内可直连），失败时回退 `https://go.dev/VERSION?m=text`；两者都不可达时回退到内置默认 1.26.6 并给出警告，不会让脚本卡死或失败。

需要固定版本时，三种方式任选（优先级：旗标 > 环境变量 > 位置参数）：

```bash
# 位置参数（第三个）
./build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale 1.26.6

# 选项
./build_feed.sh /path/to/openwrt/buildroot --go-version 1.26.6
./build_feed.sh /path/to/openwrt/buildroot --go-version=1.26.6

# 环境变量
GO_VERSION=1.26.6 ./build_feed.sh /path/to/openwrt/buildroot
```

固定版本时会跳过网络查询，完全离线可用。

### 只配置不编译

```bash
./build_feed.sh /path/to/openwrt/buildroot --no-compile
```

跳过编译、产物校验和索引生成（隐含 `--no-index`），结束时提示手动编译命令。适合先把环境配好、编译时机自己控制的场景。

### 一行式在线执行

无需本地检出：

```bash
bash <(curl -fsSL https://raw.githubusercontent.com/GuNanOvO/openwrt-tailscale/main/build_scripts/build_feed.sh) /path/to/openwrt/buildroot
```

此模式下配套的 Go 准备脚本会自动下载到临时目录执行。

## 命令行选项

| 选项 | 说明 |
| --- | --- |
| `--no-index` | 跳过 `make package/index`。适合只要 .ipk/.apk、不需要本地软件源索引的场景 |
| `--no-compile` | 跳过编译，只完成 Go 准备、feed 配置更新、官方包移除、包安装、`.config` 勾选（隐含 `--no-index`） |
| `--go-version <ver>` | 指定 Go 工具链版本，与第三个位置参数等价 |
| `-h` / `--help` | 显示完整帮助 |

选项与位置参数可任意混用；未知选项直接报错；`--` 可显式分隔。

## 环境变量

| 变量 | 默认值 | 说明 |
| --- | --- | --- |
| `REPO_URL` | `https://github.com/GuNanOvO/openwrt-tailscale.git` | 远程模式 Git 地址，网络受限时指向镜像 |
| `JOBS` | `nproc` | 并行编译任务数，内存紧张时可调小 |
| `GO_VERSION` | （自动检测） | 固定 Go 版本，同 `--go-version` |
| `GO_VERSION_API` | `https://golang.google.cn/VERSION?m=text` | 最新版查询地址，可指向自建镜像 |
| `GO_DL_BASE` | `https://golang.google.cn/dl` | 配套脚本的 Go 下载源（`prepare_go_for_openwrt.sh`） |

```bash
# 镜像仓库示例
REPO_URL=https://ghfast.top/https://github.com/GuNanOvO/openwrt-tailscale.git ./build_feed.sh ~/openwrt

# 限制并行度
JOBS=2 ./build_feed.sh ~/openwrt --no-compile

# 离线固定 Go 版本
GO_VERSION=1.26.6 ./build_feed.sh ~/openwrt --no-compile
```

## 执行流程

| 步骤 | 内容 |
| --- | --- |
| 0. 确定版本 | 用户未固定时，从 `golang.google.cn`（回退 `go.dev`）查询最新稳定 Go 版本；全部不可达时回退内置默认 1.26.6 并警告 |
| 1. 准备 Go | 调用 `prepare_go_for_openwrt.sh` 覆盖 buildroot 自带 Go（安装到 `staging_dir/hostpkg/go`）；下载源 `golang.google.cn/dl` 优先、`go.dev/dl` 回退；本地无配套脚本时自动下载 |
| 2. 配置 feed | 自动识别活跃配置文件（`feeds.conf` 存在则优先于 `feeds.conf.default`），写入 feed 条目，名固定 `openwrt_tailscale`；首次运行生成单一 `.bak` 备份 |
| 3. 更新 feed | 删除旧检出目录后 `./scripts/feeds update openwrt_tailscale`，保证干净状态 |
| 4. 移除官方包 | 删除其他 feed 下已安装的 `tailscale`/`tailscaled` 链接 |
| 5. 安装包 | `./scripts/feeds install -a -p openwrt_tailscale`，建立 `package/feeds/openwrt_tailscale/tailscale` symlink |
| 6. 勾选 | 写入 `CONFIG_PACKAGE_tailscale=y` 并 `make defconfig` 固化 |
| 7. 编译 | 清理后 `make package/feeds/openwrt_tailscale/tailscale/compile -j$JOBS V=s` |
| 8. 校验产物 | 在 `bin/` 按**修改时间取最新**匹配 `tailscale_*.ipk` / `tailscale-*.apk`（apk 用连字符，两种命名均兼容） |
| 9. 生成索引 | `make package/index` 并确认索引含 tailscale；失败仅警告不中断 |

> **关于 Step 4/5 的顺序**：OpenWrt 的 `feeds install` 对已从其他 feed 安装的同名包会静默跳过，因此必须**先删官方包再 install**，否则首次运行时不会创建 `package/feeds/openwrt_tailscale/tailscale` 符号链接，脚本会报 "Feed package not found"。

## 输出产物

安装包位于 `bin/packages/<架构>/base/`，例如：

```
bin/packages/x86_64/base/tailscale_1.102.3-1_x86_64.ipk   # OpenWrt 24.10 及更早（opkg）
bin/packages/x86_64/base/tailscale-1.102.3-r1-x86_64.apk  # OpenWrt 25.12 起（apk）
```

安装命令：

```bash
opkg install <文件路径>                    # ipk
apk add --allow-untrusted <文件路径>      # apk
```

`--no-compile` 之后手动编译：

```bash
make package/feeds/openwrt_tailscale/tailscale/compile -j$(nproc) V=s
```

## FAQ

**Q：跑了 `./scripts/feeds update -a && ./scripts/feeds install -a`，官方旧版 tailscale 又回来了？**

A：OpenWrt feed 机制的预期行为（install 会恢复所有 feed 的包链接）。重跑本脚本即可再次覆盖，脚本为此设计为幂等。

**Q：为什么改的是 `feeds.conf` 而不是 `feeds.conf.default`（或反之）？**

A：OpenWrt 的 `scripts/feeds` 只要 `feeds.conf` 存在就完全忽略 `feeds.conf.default`。脚本自动检测活跃文件并在其中操作，日志会打印 `Active feeds config:` 指明。

**Q：`make defconfig` 报错，或 tailscale 没进 `.config`？**

A：用 `make menuconfig` 检查依赖。tailscale 依赖 `+ca-bundle +kmod-tun` 及 Go 架构依赖，目标配置异常时 defconfig 会将其降级为未选中。

**Q：Go 下载慢或失败？**

A：版本查询与下载均优先走 `golang.google.cn`（国内直连），失败自动回退 `go.dev`。已下载的文件缓存在 `buildroot/dl/go-toolchain/`，重试不重新下载。内网环境可通过 `GO_VERSION_API` / `GO_DL_BASE` 环境变量指向自建镜像。

**Q：删除官方包会破坏 buildroot 吗？**

A：不会。删除的只是 `package/feeds/` 下的符号链接，feed 本身（`feeds/packages/`）不受影响，`./scripts/feeds install` 可随时恢复。feed 配置写入前保留一份 `.bak`（只保留最早一份，不堆积）。

## 维护说明

- 上游仓库 Makefile 变更包名时，Step 5 的 `PKG_LINK` 检查会报错并列出 `package/feeds/` 实际结构，便于排查
- 脚本依赖的 feed 行为（配置优先级、install 跳过逻辑）基于 OpenWrt 24.10 分支源码核实，注释中记录了依据
- Go 版本自动检测的返回格式校验为 `^go[0-9]+(\.[0-9]+)*$`，官方接口变更时需同步更新正则与回退逻辑