### PR TITLE
Merge community build_feed.sh improvements (PR #158) + attribution

### DIFF
--- a/build_scripts/build_feed.sh
+++ b/build_scripts/build_feed.sh
@@ -3,6 +3,12 @@
 # The package keeps the official name `tailscale`, so the buildroot's stale official
 # tailscale (e.g. from a frozen openwrt/packages branch) is replaced instead of duplicated.
 #
+# Maintainer: @Potterli20 (https://github.com/Potterli20) - community-contributed,
+#             originally requested in issue #142
+#             (https://github.com/GuNanOvO/openwrt-tailscale/issues/142).
+#             This script is maintained by its contributors; it is not part of the
+#             core package distribution workflow of this repository.
+#
 # Usage:
 #   # Remote mode (GitHub feed, recommended for firmware builds):
 #   ./build_feed.sh /path/to/openwrt/buildroot


### PR DESCRIPTION
## 概要

将 PR #158（@Potterli20 的 build_feed.sh 重构）合入 main，并补充维护者署名。

### 变更

- **`build_scripts/build_feed.sh`**（来自 #158，+348/-95）：
  - 修复关键顺序 bug：官方 tailscale 链接**先于** `feeds install` 删除（OpenWrt 对已从其他 feed 安装的同名包会静默跳过 install，原顺序会导致 "Feed package not found"）
  - 参数解析重构：`--go-version`、`--no-compile`、`--`、`-h`
  - Go 版本自动检测（golang.google.cn 优先，go.dev 回退，离线回退 1.26.6）
  - feeds.conf 优先于 feeds.conf.default 自动识别
  - 产物校验按 mtime 取最新、JOBS/REPO_URL/GO_VERSION_API 环境变量
- **`build_scripts/prepare_go_for_openwrt.sh`**（来自 #158，小幅更新）
- **attribution**：脚本头部标注 @Potterli20 维护、来源 issue #142，并声明该脚本为社区贡献、不在核心分发流程内

### 维护边界

自编译固件（buildroot feed）不在本仓库核心分发范围内；build_feed.sh 由贡献者维护，仅通过 PR review 合并，不承诺主动迭代。