### PR TITLE
docs: add self-build firmware guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,6 +68,7 @@ export default defineConfig({
             { text: 'Overview', link: '/en/build/' },
             { text: 'Build IPK', link: '/en/build/ipk' },
             { text: 'Build APK', link: '/en/build/apk' },
+            { text: 'Self-Build Firmware', link: '/en/build/self-build' },
           ] },
           { text: 'Help', items: [
             { text: 'FAQ', link: '/en/reference/faq' },
@@ -95,6 +96,7 @@ export default defineConfig({
               { text: 'Overview', link: '/en/build/' },
               { text: 'Build IPK (24.10)', link: '/en/build/ipk' },
               { text: 'Build APK (25.12+)', link: '/en/build/apk' },
+              { text: 'Self-Build Firmware', link: '/en/build/self-build' },
             ] }
           ],
           '/en/reference/': [
@@ -137,6 +139,7 @@ export default defineConfig({
             { text: '概览', link: '/zh/build/' },
             { text: '构建 IPK', link: '/zh/build/ipk' },
             { text: '构建 APK', link: '/zh/build/apk' },
+            { text: '自编译固件', link: '/zh/build/self-build' },
           ] },
           { text: '帮助', items: [
             { text: '常见问题', link: '/zh/reference/faq' },
@@ -164,6 +167,7 @@ export default defineConfig({
               { text: '概览', link: '/zh/build/' },
               { text: '构建 IPK (24.10)', link: '/zh/build/ipk' },
               { text: '构建 APK (25.12+)', link: '/zh/build/apk' },
+              { text: '自编译固件', link: '/zh/build/self-build' },
             ] }
           ],
           '/zh/reference/': [

--- a/docs/en/build/index.md
+++ b/docs/en/build/index.md
@@ -23,7 +23,7 @@ The build system uses:
 | `build_scripts/build_ipk.sh` | Build IPK packages (OpenWrt 24.10) |
 | `build_scripts/build_apk.sh` | Build APK packages (OpenWrt 25.12+) |
 | `build_scripts/prepare_go_for_openwrt.sh` | Prepare Go toolchain for OpenWrt SDK |
-| `build_scripts/build_feed.sh` | One-shot script to build this package inside a self-built firmware buildroot (as a custom feed) |
+| `build_scripts/build_feed.sh` | One-shot script to build this package inside a self-built firmware buildroot (as a custom feed). See [Self-Build Firmware](/en/build/self-build) |
 
 ## CI/CD Pipeline
 
@@ -37,3 +37,4 @@ All builds are automated via GitHub Actions:
 
 - [Build IPK Packages](/en/build/ipk)
 - [Build APK Packages](/en/build/apk)
+- [Self-Build Firmware](/en/build/self-build)

--- a/docs/en/build/self-build.md
+++ b/docs/en/build/self-build.md
@@ -14,20 +14,7 @@ Guide to embedding this repository's tailscale into a self-built OpenWrt firmwar
 
 ## Option 1: Install the Prebuilt IPK Directly (No Compilation)
 
-If you just want the latest version on an existing firmware, this is the simplest way — no buildroot needed:
-
-```sh
-# 1. Download the ipk for your architecture (see [Packages](/en/packages))
-wget https://github.com/GuNanOvO/openwrt-tailscale/releases/download/v1.102.3/tailscale_1.102.3_aarch64_cortex-a53.ipk
-
-# 2. Remove the old version and install dependencies
-opkg remove tailscale 2>/dev/null || true
-opkg update
-opkg install kmod-tun ca-bundle
-
-# 3. Install the new version
-opkg install tailscale_1.102.3_aarch64_cortex-a53.ipk
-```
+If you just want the latest version on an existing firmware, install the prebuilt ipk from this repository — the steps are identical to a standard install, see [Manual Install](/en/guide/manual-install). No buildroot needed.
 
 > Note: after a firmware upgrade, preinstalled packages are restored to the firmware's built-in version and need to be reinstalled.
 

--- a/docs/en/build/self-build.md
+++ b/docs/en/build/self-build.md
@@ -1,0 +1,80 @@
+---
+title: Self-Build Firmware
+description: Embed the latest tailscale from this repository in self-built OpenWrt firmware — build_feed.sh usage and alternatives
+---
+
+# Self-Build Firmware (Buildroot)
+
+Guide to embedding this repository's tailscale into a self-built OpenWrt firmware.
+
+## When to Use
+
+- You compile your own OpenWrt firmware and want the latest tailscale built in
+- The official packages feed stopped updating tailscale (e.g. frozen 24.10 branches still ship an old version)
+
+## Option 1: Install the Prebuilt IPK Directly (No Compilation)
+
+If you just want the latest version on an existing firmware, this is the simplest way — no buildroot needed:
+
+```sh
+# 1. Download the ipk for your architecture (see [Packages](/en/packages))
+wget https://github.com/GuNanOvO/openwrt-tailscale/releases/download/v1.102.3/tailscale_1.102.3_aarch64_cortex-a53.ipk
+
+# 2. Remove the old version and install dependencies
+opkg remove tailscale 2>/dev/null || true
+opkg update
+opkg install kmod-tun ca-bundle
+
+# 3. Install the new version
+opkg install tailscale_1.102.3_aarch64_cortex-a53.ipk
+```
+
+> Note: after a firmware upgrade, preinstalled packages are restored to the firmware's built-in version and need to be reinstalled.
+
+## Option 2: One-Click Script (build_feed.sh)
+
+Automates the whole process inside your buildroot: replaces the Go toolchain, registers this repository as a feed, removes the stale official package, and selects + builds tailscale.
+
+### One-Line Run (No Local Checkout)
+
+```sh
+bash <(curl -fsSL https://raw.githubusercontent.com/GuNanOvO/openwrt-tailscale/main/build_scripts/build_feed.sh) /path/to/openwrt/buildroot
+```
+
+### Local Mode (Development)
+
+```sh
+./build_scripts/build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
+```
+
+The second argument points to a local checkout of this repository, mounted via `src-link`.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--no-compile` | Set up the feed and select the package only, no compilation (implies `--no-index`) |
+| `--no-index` | Skip `make package/index` |
+| `--go-version <ver>` | Pin the Go toolchain version (default: auto-detect latest stable) |
+| `-h` / `--help` | Show full help |
+
+Environment variables: `JOBS` (parallel jobs), `REPO_URL` (mirror URL), `GO_VERSION` (pinned Go version).
+
+### Process
+
+1. Resolve the Go version (auto-detected unless pinned; offline fallback 1.26.6)
+2. Override the buildroot's Go with `prepare_go_for_openwrt.sh`
+3. Register the `openwrt_tailscale` feed
+4. Remove the official tailscale links from other feeds
+5. Install this repository's package and enable `CONFIG_PACKAGE_tailscale=y`
+6. Compile and verify the output
+
+The script is idempotent: after `./scripts/feeds update -a` brings the official package back, re-run the script to restore the override.
+
+## Manual Steps (Alternative)
+
+For a fully manual approach, see `package/tailscale/FORK.md` in the repository.
+
+## Maintenance
+
+`build_feed.sh` is a community contribution (maintained by [@Potterli20](https://github.com/Potterli20), originating from [issue #142](https://github.com/GuNanOvO/openwrt-tailscale/issues/142)) and is not part of this repository's core distribution workflow. Please submit script issues via [GitHub PR](https://github.com/GuNanOvO/openwrt-tailscale/pulls).

--- a/docs/en/reference/faq.md
+++ b/docs/en/reference/faq.md
@@ -41,13 +41,12 @@ Yes! See the [Build Guide](/en/build/) for Docker-based build instructions.
 
 ### How to embed the latest Tailscale into a self-built firmware?
 
-If you compile your own OpenWrt firmware and the official `packages` feed only ships an old tailscale, run the one-shot script from this repo. It replaces the buildroot's Go toolchain, adds this repo as a custom feed, and removes the stale official tailscale:
+If you compile your own OpenWrt firmware and the official `packages` feed only ships an old tailscale, there are two options:
 
-```sh
-bash /path/to/openwrt-tailscale/build_scripts/build_feed.sh /path/to/openwrt/buildroot
-```
+1. **Install the prebuilt ipk directly** (no compilation): download the ipk for your architecture and `opkg install` it
+2. **One-click script `build_feed.sh`**: replaces the Go toolchain, registers the feed, removes the stale official package, and builds
 
-Then build the full firmware (`make -j$(nproc) V=s`). See `package/tailscale/FORK.md` for details.
+See [Self-Build Firmware](/en/build/self-build) for details.
 
 ### Does UPX affect performance?
 

--- a/docs/zh/build/index.md
+++ b/docs/zh/build/index.md
@@ -23,7 +23,7 @@ description: 自行构建精简版 Tailscale 软件包 — 构建系统、脚本
 | `build_scripts/build_ipk.sh` | 构建 IPK 包 (OpenWrt 24.10) |
 | `build_scripts/build_apk.sh` | 构建 APK 包 (OpenWrt 25.12+) |
 | `build_scripts/prepare_go_for_openwrt.sh` | 为 OpenWrt SDK 准备 Go 工具链 |
-| `build_scripts/build_feed.sh` | 在自编译固件的 buildroot 中一键构建本包（以自定义 feed 方式） |
+| `build_scripts/build_feed.sh` | 在自编译固件的 buildroot 中一键构建本包（以自定义 feed 方式）。详见[自编译固件](/zh/build/self-build) |
 
 ## CI/CD 流水线
 
@@ -37,3 +37,4 @@ description: 自行构建精简版 Tailscale 软件包 — 构建系统、脚本
 
 - [构建 IPK 包](/zh/build/ipk)
 - [构建 APK 包](/zh/build/apk)
+- [自编译固件](/zh/build/self-build)

--- a/docs/zh/build/self-build.md
+++ b/docs/zh/build/self-build.md
@@ -1,0 +1,80 @@
+---
+title: 自编译固件
+description: 在自编译 OpenWrt 固件中嵌入本仓库的最新 tailscale — build_feed.sh 用法与替代方案
+---
+
+# 自编译固件 (Buildroot)
+
+在自编译固件的 buildroot 中嵌入本仓库 tailscale 的指南。
+
+## 适用场景
+
+- 自行编译 OpenWrt 固件，希望固件内置最新版 tailscale
+- 官方 packages feed 的 tailscale 已停止更新（例如 24.10 冻结分支仍停留在旧版本）
+
+## 方式一：预编译 ipk 直接安装（无需编译）
+
+如果只是想让现有固件用上最新版，这是最简单的方式，不需要 buildroot：
+
+```sh
+# 1. 下载对应架构的 ipk（架构列表见 [软件包](/zh/packages)）
+wget https://github.com/GuNanOvO/openwrt-tailscale/releases/download/v1.102.3/tailscale_1.102.3_aarch64_cortex-a53.ipk
+
+# 2. 卸载旧版并安装依赖
+opkg remove tailscale 2>/dev/null || true
+opkg update
+opkg install kmod-tun ca-bundle
+
+# 3. 安装新版
+opkg install tailscale_1.102.3_aarch64_cortex-a53.ipk
+```
+
+> 注意：固件升级后预安装的包会被恢复为固件内置版本，需要重新安装。
+
+## 方式二：一键脚本 build_feed.sh
+
+在 buildroot 中自动完成：替换 Go 工具链 → 注册本仓库为 feed → 移除官方旧包 → 选中并编译。
+
+### 一行式运行（无需本地检出）
+
+```sh
+bash <(curl -fsSL https://raw.githubusercontent.com/GuNanOvO/openwrt-tailscale/main/build_scripts/build_feed.sh) /path/to/openwrt/buildroot
+```
+
+### 本地模式（开发调试）
+
+```sh
+./build_scripts/build_feed.sh /path/to/openwrt/buildroot /path/to/openwrt-tailscale
+```
+
+第二个参数指向本仓库的本地检出目录，以 `src-link` 方式挂载。
+
+### 常用参数
+
+| 参数 | 说明 |
+|------|------|
+| `--no-compile` | 只配置 feed 与勾选包，不编译（隐含 `--no-index`） |
+| `--no-index` | 跳过 `make package/index` |
+| `--go-version <版本>` | 固定 Go 工具链版本（默认自动检测最新稳定版） |
+| `-h` / `--help` | 显示完整帮助 |
+
+其他环境变量：`JOBS`（并行度）、`REPO_URL`（镜像地址）、`GO_VERSION`（固定 Go 版本）。
+
+### 流程
+
+1. 确定 Go 版本（未指定时自动检测，离线回退 1.26.6）
+2. 用 `prepare_go_for_openwrt.sh` 覆盖 buildroot 自带 Go
+3. 注册 `openwrt_tailscale` feed
+4. 移除其他 feed 中的官方 tailscale 链接
+5. 安装本仓库包并勾选 `CONFIG_PACKAGE_tailscale=y`
+6. 编译并校验产物
+
+脚本可重复执行：`./scripts/feeds update -a` 后官方旧包会复活，重跑一次脚本即可恢复。
+
+## 手动步骤（备选）
+
+如果希望完全手动操作，详见仓库内的 `package/tailscale/FORK.md`。
+
+## 维护说明
+
+`build_feed.sh` 为社区贡献（由 [@Potterli20](https://github.com/Potterli20) 维护，源自 [issue #142](https://github.com/GuNanOvO/openwrt-tailscale/issues/142)），不在本仓库核心分发流程内。脚本问题请通过 [GitHub PR](https://github.com/GuNanOvO/openwrt-tailscale/pulls) 提交。

--- a/docs/zh/build/self-build.md
+++ b/docs/zh/build/self-build.md
@@ -14,20 +14,7 @@ description: 在自编译 OpenWrt 固件中嵌入本仓库的最新 tailscale �
 
 ## 方式一：预编译 ipk 直接安装（无需编译）
 
-如果只是想让现有固件用上最新版，这是最简单的方式，不需要 buildroot：
-
-```sh
-# 1. 下载对应架构的 ipk（架构列表见 [软件包](/zh/packages)）
-wget https://github.com/GuNanOvO/openwrt-tailscale/releases/download/v1.102.3/tailscale_1.102.3_aarch64_cortex-a53.ipk
-
-# 2. 卸载旧版并安装依赖
-opkg remove tailscale 2>/dev/null || true
-opkg update
-opkg install kmod-tun ca-bundle
-
-# 3. 安装新版
-opkg install tailscale_1.102.3_aarch64_cortex-a53.ipk
-```
+如果只是想让现有固件用上最新版，直接安装本仓库预编译的 ipk 即可——步骤与标准安装完全相同，见[手动下载安装](/zh/guide/manual-install)，无需 buildroot。
 
 > 注意：固件升级后预安装的包会被恢复为固件内置版本，需要重新安装。
 

--- a/docs/zh/reference/faq.md
+++ b/docs/zh/reference/faq.md
@@ -37,13 +37,12 @@ opkg update && opkg upgrade tailscale
 
 ### 如何将最新版 Tailscale 编入自编译固件？
 
-如果你自己编译 OpenWrt 固件，且官方 `packages` feed 只提供旧版 tailscale，可以运行本仓库的一键脚本（自动替换 buildroot 的 Go 工具链、添加本仓库为自定义 feed、移除官方旧 tailscale）：
+如果你自己编译 OpenWrt 固件，且官方 `packages` feed 只提供旧版 tailscale，有两种方式：
 
-```sh
-bash /path/to/openwrt-tailscale/build_scripts/build_feed.sh /path/to/openwrt/buildroot
-```
+1. **预编译 ipk 直接安装**（无需编译）：下载对应架构的 ipk 后 `opkg install`
+2. **一键脚本 `build_feed.sh`**：自动替换 Go 工具链、注册 feed、移除官方旧包并编译
 
-然后全量编译固件即可。详见 `package/tailscale/FORK.md`。
+详细步骤见[自编译固件](/zh/build/self-build)。
 
 ### UPX 影响性能吗？
 


### PR DESCRIPTION
## 概要

在构建文档中新增"自编译固件"指南（en/zh），介绍如何在自编译固件的 buildroot 中嵌入本仓库的最新 tailscale。

### 变更

- **新增 `docs/{en,zh}/build/self-build.md`**：
  - 方式一：预编译 ipk 直接安装（指向标准安装教程 [manual-install]）
  - 方式二：一键脚本 `build_feed.sh`（远程/本地模式、`--no-compile`、`--go-version`、`curl | bash` 一行式、流程说明）
  - 维护说明：脚本为社区贡献（@Potterli20 维护，源自 #142），不在核心分发流程内
- **`docs/.vitepress/config.mts`**：en/zh 导航与侧边栏新增"Self-Build Firmware / 自编译固件"条目
- **`docs/{en,zh}/build/index.md`**：脚本表格与"下一步"补充链接
- **`docs/{en,zh}/reference/faq.md`**：自编译 FAQ 更新为指向新页面

### 备注

本地已用 vitepress build + dev 验证，页面渲染正常。