### PR TITLE
fix: restore Peer Relay support (ts_omit_relayserver), r2

### DIFF
--- a/build_scripts/build_apk.sh
+++ b/build_scripts/build_apk.sh
@@ -50,14 +50,19 @@ echo "Using $(/builder/go/bin/go version)"
 # build tailscale package
 make package/tailscale/compile -j$(nproc) V=s
 
-# check package build result
-if [ -f /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r1.apk ]; then
-    echo "Build Success: APK Package generated at /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r1.apk"
+# check package build result (match any -rN, PKG_RELEASE may change)
+SDK_APK=$(ls /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r*.apk 2>/dev/null | head -n1)
+if [ -n "$SDK_APK" ]; then
+    echo "Build Success: APK Package generated at ${SDK_APK}"
     ls -lh /builder/bin/packages/${TARGET_ARCH}/base/
 else
     echo "Error: No build product found at expected location"
     exit 1
 fi
+
+# rename to the intermediate name expected by the release workflow
+mv "$SDK_APK" /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r1.apk
+ls -lh /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r1.apk
 
 # change to package directory for index generation and signing
 echo "Making index and signing index..."

--- a/build_scripts/build_ipk.sh
+++ b/build_scripts/build_ipk.sh
@@ -52,9 +52,10 @@ echo "Using $(/builder/go/bin/go version)"
 echo "Building Tailscale IPK package..."
 make package/tailscale/compile -j$(nproc) V=s
 
-# check package build result
-if [ -f /builder/bin/packages/${TARGET_ARCH}/base/tailscale_${PKG_VERSION}-r1_${TARGET_ARCH}.ipk ]; then
-    echo "Build Success: IPK Package generated at /builder/bin/packages/${TARGET_ARCH}/base/tailscale_${PKG_VERSION}-r1_${TARGET_ARCH}.ipk"
+# check package build result (match any -rN, PKG_RELEASE may change)
+SDK_IPK=$(ls /builder/bin/packages/${TARGET_ARCH}/base/tailscale_${PKG_VERSION}-r*_${TARGET_ARCH}.ipk 2>/dev/null | head -n1)
+if [ -n "$SDK_IPK" ]; then
+    echo "Build Success: IPK Package generated at ${SDK_IPK}"
     ls -lh /builder/bin/packages/${TARGET_ARCH}/base/
 else
     echo "Error: No build product found at expected location"
@@ -62,9 +63,9 @@ else
     exit 1
 fi
 
-# rename the generated ipk package to standard format: tailscale-${PKG_VERSION}-r1.ipk
+# rename the generated ipk package to the intermediate name expected by the release workflow
 echo "Renaming generated IPK package to standard format..."
-mv /builder/bin/packages/${TARGET_ARCH}/base/tailscale_${PKG_VERSION}-r1_${TARGET_ARCH}.ipk /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r1.ipk
+mv "$SDK_IPK" /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r1.ipk
 ls -lh /builder/bin/packages/${TARGET_ARCH}/base/tailscale-${PKG_VERSION}-r1.ipk
 
 cp /builder/keys/key-build.sec ./key-build

--- a/package/tailscale/Makefile
+++ b/package/tailscale/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tailscale
 PKG_VERSION:=1.102.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tailscale/tailscale/tar.gz/v$(PKG_VERSION)?
@@ -28,7 +28,7 @@ PKG_BUILD_FLAGS:=no-mips16
 GO_PKG:=tailscale.com/cmd/tailscaled
 GO_PKG_LDFLAGS:=-s -w -X 'tailscale.com/version.longStamp=$(PKG_VERSION)-$(PKG_RELEASE) (OpenWrt-UPX)'
 GO_PKG_LDFLAGS_X:=tailscale.com/version.shortStamp=$(PKG_VERSION)
-GO_PKG_TAGS:=ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_relayserver,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
+GO_PKG_TAGS:=ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
 
 ifneq ($(filter mips64% riscv64% loongarch64%,$(ARCH)),)
   DISABLE_UPX:=1


### PR DESCRIPTION
## 问题

Issue #161：1.102.4-r1 无法启用/宣告 Peer Relay 功能，官方 packages feed 版本正常。

## 根因

`GO_PKG_TAGS` 中的 `ts_omit_relayserver` 裁掉了 Relay server 功能（Peer Relay 实现）：
- `feature/buildfeatures/feature_relayserver_enabled.go`：`HasRelayServer = !ts_omit_relayserver`
- `cmd/tailscale/cli/debug-peer-relay.go` 构建约束：`!ts_omit_relayserver`
- 官方 openwrt/packages 未使用此 tag

## 修复

- 从 `GO_PKG_TAGS` 移除 `ts_omit_relayserver`（其余裁剪保留）
- `PKG_RELEASE:=2`，使已安装 r1 的用户可经 opkg/apk 升级
- `build_ipk.sh` / `build_apk.sh`：匹配任意 `-rN` SDK 产物并重命名为 workflow 中间约定名，构建脚本不再硬编码 r1

## 发布

合并后手动触发 `build-tailscale` workflow 重编译，同 tag `v1.102.4` 覆盖发布（资产名不变，feed index 更新为 r2）。