### PR TITLE
feat: support -rN releases in install scripts and version workflows

### DIFF
--- a/.github/workflows/build-tailscale.yml
+++ b/.github/workflows/build-tailscale.yml
@@ -170,11 +170,12 @@ jobs:
         id: get_build_version
         run: |
           VERSION=$(sed -n 's/^PKG_VERSION:=\(.*\)/\1/p' repo/package/tailscale/Makefile | tr -d '[:space:]')
+          RELEASE=$(sed -n 's/^PKG_RELEASE:=\(.*\)/\1/p' repo/package/tailscale/Makefile | tr -d '[:space:]')
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "release=$RELEASE" >> $GITHUB_OUTPUT
 
-
-          echo "Parsed version: $VERSION"
+          echo "Parsed version: $VERSION (release r$RELEASE)"
 
           echo "Directories prepared:"
           ls -la
@@ -306,7 +307,7 @@ jobs:
 
           du -b "${{ env.ARTIFACT_DIR }}/${{ matrix.platform }}"/tailscaled | cut -f1 > "${{ env.ARTIFACT_DIR }}/${{ matrix.platform }}/bin.size"
 
-          echo "${{ steps.get_build_version.outputs.version }}" > "${{ env.ARTIFACT_DIR }}/${{ matrix.platform }}/version"
+          echo "${{ steps.get_build_version.outputs.version }}-r${{ steps.get_build_version.outputs.release }}" > "${{ env.ARTIFACT_DIR }}/${{ matrix.platform }}/version"
 
           if [ -f "${{ env.ARTIFACT_DIR }}/${{ matrix.platform }}/tailscale-${{ steps.get_build_version.outputs.version }}-r1.ipk" ]; then
             sha256sum "${{ env.ARTIFACT_DIR }}/${{ matrix.platform }}/tailscale-${{ steps.get_build_version.outputs.version }}-r1.ipk" | awk '{print $1}' > "${{ env.ARTIFACT_DIR }}/${{ matrix.platform }}/ipk.sha256"

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -250,6 +250,7 @@ jobs:
           echo "New Hash: $NEW_HASH"
 
           sed -i "s/^PKG_VERSION:=.*/PKG_VERSION:=$NEW_VER/" package/tailscale/Makefile
+          sed -i "s/^PKG_RELEASE:=.*/PKG_RELEASE:=1/" package/tailscale/Makefile
           sed -i "s/^PKG_HASH:=.*/PKG_HASH:=$NEW_HASH/" package/tailscale/Makefile
           sed -i "s/PKG_COMMIT:=.*/PKG_COMMIT:=$NEW_COMMIT/" package/tailscale/Makefile
 

--- a/install.sh
+++ b/install.sh
@@ -173,7 +173,10 @@ check_tailscale_install_status() {
 
     if command -v tailscale >/dev/null 2>&1; then
         local version_output
-        version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+        version_output=$(tailscale version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' | head -n 1 | sed 's/-\([0-9][0-9]*\)$/-r\1/')
+        if [ -z "$version_output" ]; then
+            version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+        fi
         [ -n "$version_output" ] && TAILSCALE_LOCAL_VERSION="$version_output"
     fi
 
@@ -224,7 +227,10 @@ check_tailscale_install_status() {
             IS_TAILSCALE_INSTALLED="true"
             if command -v tailscale >/dev/null 2>&1; then
                 local version_output
-                version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+                version_output=$(tailscale version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' | head -n 1 | sed 's/-\([0-9][0-9]*\)$/-r\1/')
+                if [ -z "$version_output" ]; then
+                    version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+                fi
                 [ -n "$version_output" ] && TAILSCALE_LOCAL_VERSION="$version_output"
             fi
         fi
@@ -337,7 +343,9 @@ get_tailscale_info() {
     fi
 
     TAILSCALE_LATEST_VERSION="$version"
-    TAILSCALE_FILE="tailscale-${TAILSCALE_LATEST_VERSION}-r1"
+    # version file may carry a release suffix (e.g. 1.102.4-r2); the package
+    # file name convention only uses the upstream version (tailscale-<ver>-r1)
+    TAILSCALE_FILE="tailscale-${TAILSCALE_LATEST_VERSION%-r*}-r1"
     TAILSCALE_FILE_SIZE=$((file_size / 1024 / 1024))
 
     if [ "$DEVICE_STORAGE_AVAILABLE" -gt "$TAILSCALE_FILE_SIZE" ]; then
@@ -627,10 +635,8 @@ persistent_install() {
     for install_attempt in $install_attempt_range; do
         echo "[INFO]: 安装尝试 $install_attempt/3"
         if [ "$PACKAGE_MANAGER" = "opkg" ]; then
-            echo "[INFO]: 移除旧的tailscale包..."
-            opkg remove tailscale 2>/dev/null || true
-            echo "[INFO]: 安装tailscale IPK包..."
-            if opkg install /tmp/$TAILSCALE_FILE.ipk; then
+            echo "[INFO]: 安装/更新tailscale IPK包..."
+            if opkg install --force-reinstall /tmp/$TAILSCALE_FILE.ipk; then
                 install_success=true
                 echo "[INFO]: IPK包安装成功"
                 rm -f "/tmp/$TAILSCALE_FILE.ipk" "/tmp/$TAILSCALE_FILE.sha256"
@@ -639,10 +645,8 @@ persistent_install() {
                 echo "[INFO]: IPK包安装失败，准备重试..."
             fi
         elif [ "$PACKAGE_MANAGER" = "apk" ]; then
-            echo "[INFO]: 移除旧的tailscale包..."
-            apk del tailscale 2>/dev/null || true
-            echo "[INFO]: 安装tailscale APK包..."
-            if apk add --allow-untrusted /tmp/$TAILSCALE_FILE.apk; then
+            echo "[INFO]: 安装/更新tailscale APK包..."
+            if apk add --allow-untrusted --force-overwrite /tmp/$TAILSCALE_FILE.apk; then
                 install_success=true
                 echo "[INFO]: APK包安装成功"
                 rm -f "/tmp/$TAILSCALE_FILE.apk" "/tmp/$TAILSCALE_FILE.sha256"

--- a/install_en.sh
+++ b/install_en.sh
@@ -153,7 +153,10 @@ check_tailscale_install_status() {
 
     if command -v tailscale >/dev/null 2>&1; then
         local version_output
-        version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+        version_output=$(tailscale version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' | head -n 1 | sed 's/-\([0-9][0-9]*\)$/-r\1/')
+        if [ -z "$version_output" ]; then
+            version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+        fi
         [ -n "$version_output" ] && TAILSCALE_LOCAL_VERSION="$version_output"
     fi
 
@@ -204,7 +207,10 @@ check_tailscale_install_status() {
             IS_TAILSCALE_INSTALLED="true"
             if command -v tailscale >/dev/null 2>&1; then
                 local version_output
-                version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+                version_output=$(tailscale version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' | head -n 1 | sed 's/-\([0-9][0-9]*\)$/-r\1/')
+                if [ -z "$version_output" ]; then
+                    version_output=$(tailscale version 2>/dev/null | head -n 1 | tr -d '[:space:]')
+                fi
                 [ -n "$version_output" ] && TAILSCALE_LOCAL_VERSION="$version_output"
             fi
         fi
@@ -283,7 +289,9 @@ get_tailscale_info() {
     fi
 
     TAILSCALE_LATEST_VERSION="$version"
-    TAILSCALE_FILE="tailscale-${TAILSCALE_LATEST_VERSION}-r1"
+    # version file may carry a release suffix (e.g. 1.102.4-r2); the package
+    # file name convention only uses the upstream version (tailscale-<ver>-r1)
+    TAILSCALE_FILE="tailscale-${TAILSCALE_LATEST_VERSION%-r*}-r1"
     TAILSCALE_FILE_SIZE=$((file_size / 1024 / 1024))
 
     if [ "$DEVICE_STORAGE_AVAILABLE" -gt "$TAILSCALE_FILE_SIZE" ]; then
@@ -577,10 +585,8 @@ persistent_install() {
     for install_attempt in $install_attempt_range; do
         echo "[INFO]: Installation attempt $install_attempt/3"
         if [ "$PACKAGE_MANAGER" = "opkg" ]; then
-            echo "[INFO]: Removing old tailscale package..."
-            opkg remove tailscale 2>/dev/null || true
-            echo "[INFO]: Installing tailscale IPK package..."
-            if opkg install /tmp/$TAILSCALE_FILE.ipk; then
+            echo "[INFO]: Installing/updating tailscale IPK package..."
+            if opkg install --force-reinstall /tmp/$TAILSCALE_FILE.ipk; then
                 install_success=true
                 echo "[INFO]: IPK package installation successful"
                 rm -f "/tmp/$TAILSCALE_FILE.ipk" "/tmp/$TAILSCALE_FILE.sha256"
@@ -589,10 +595,8 @@ persistent_install() {
                 echo "[INFO]: IPK package installation failed, preparing to retry..."
             fi
         elif [ "$PACKAGE_MANAGER" = "apk" ]; then
-            echo "[INFO]: Removing old tailscale package..."
-            apk del tailscale 2>/dev/null || true
-            echo "[INFO]: Installing tailscale APK package..."
-            if apk add --allow-untrusted /tmp/$TAILSCALE_FILE.apk; then
+            echo "[INFO]: Installing/updating tailscale APK package..."
+            if apk add --allow-untrusted --force-overwrite /tmp/$TAILSCALE_FILE.apk; then
                 install_success=true
                 echo "[INFO]: APK package installation successful"
                 rm -f "/tmp/$TAILSCALE_FILE.apk" "/tmp/$TAILSCALE_FILE.sha256"


### PR DESCRIPTION
## 背景

#161 修复发布为 1.102.4-r2 后暴露两个问题：
1. 一键脚本感知不到 rN（feed 的 version 文件与 `tailscale version` 都比较基础版本号），重跑脚本显示"已是最新版本"，无法升级
2. `check-version.yml` 更新上游版本时不重置 `PKG_RELEASE`，新版本会一直沿用 r2

## 变更

**install.sh / install_en.sh**
- 本地版本解析：从 `long version: 1.102.4-2 (OpenWrt-UPX)` 解析并归一化为 `1.102.4-r2`（与 feed 的 version 文件格式一致；上游格式无法解析时回退基础版本）
- 下载文件名构造：剥离 `-rN`，保持 `tailscale-<ver>-r1.ipk` 约定不变
- 更新流程：去掉前置 `opkg remove tailscale` / `apk del tailscale`（会被 luci 依赖拒绝且错误被吞掉），改为 `opkg install --force-reinstall` / `apk add --allow-untrusted --force-overwrite`，保留依赖关系

**build-tailscale.yml**
- feed 的 `version` 文件写入 `<PKG_VERSION>-r<PKG_RELEASE>`（release tag、资产名不变）

**check-version.yml**
- 提交新上游版本时重置 `PKG_RELEASE:=1`

## 实测（OpenWrt 24.10 QEMU）

- busybox 解析 `long version: 1.102.4-2` → `1.102.4-r2` ✓
- `opkg --help` 确认支持 `--force-reinstall` / `--force-depends` / `--force-overwrite` ✓
- `opkg install --force-reinstall tailscale_1.102.4_x86_64.ipk` 重装成功、服务正常 ✓

## 后续

合并后需更新 feed 分支各架构的 `version` 文件为 `1.102.4-r2`（否则用户侧仍感知不到）。