### PR TITLE
docs: drop ts_omit_relayserver from documented build tags

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -112,10 +112,10 @@ wget -O /usr/bin/install.sh https://ghfast.top/https://raw.githubusercontent.com
 
 使用了下列编译参数，精简了tailscale，详见[Makefile](../package/tailscale/Makefile)：
 
-* **[TAGS](../package/tailscale/Makefile#L31)**:  
+* **[TAGS](../package/tailscale/Makefile#L33)**:  
 
 ``` text
-ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_relayserver,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
+ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
 ```
 
 * **[LDFLAGS](../package/tailscale/Makefile#L29)**:
@@ -124,7 +124,7 @@ ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_
 -s -w
 ```
 
-使用了[UPX](https://upx.github.io/)二进制文件压缩技术，并使用了以下参数，详见[Makefile](../package/tailscale/Makefile#L65-L74)：
+使用了[UPX](https://upx.github.io/)二进制文件压缩技术，并使用了以下参数，详见[Makefile](../package/tailscale/Makefile#L67-L76)：
 
 ``` text
 --best --lzma

--- a/.github/README_en.md
+++ b/.github/README_en.md
@@ -100,10 +100,10 @@ For easier usage with minimal CLI interaction, you may optionally use the commun
 The following build options are used to minimize Tailscale.
 See [Makefile](../package/tailscale/Makefile) for details:
 
-* **[TAGS](../package/tailscale/Makefile#L31)**:
+* **[TAGS](../package/tailscale/Makefile#L33)**:
 
 ```
-ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_relayserver,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
+ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
 ```
 
 * **[LDFLAGS](../package/tailscale/Makefile#L29)**:

--- a/package/tailscale/FORK.md
+++ b/package/tailscale/FORK.md
@@ -118,7 +118,7 @@ GO_ARCH=arm64 bash build_scripts/prepare_go_for_openwrt.sh /path/to/openwrt/buil
 ## 1. Build Tags (Size Reduction)
 
 ```makefile
-GO_PKG_TAGS:=ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_relayserver,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
+GO_PKG_TAGS:=ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
 ```
 
 该配置用于裁剪 Tailscale 的功能模块，从而减小最终二进制体积。
@@ -130,6 +130,8 @@ These `GO_PKG_TAGS` strip unnecessary modules from Tailscale to reduce binary si
 说明：
 Note:
 
+* `ts_omit_relayserver` **不在**裁剪列表内：该 tag 会移除 Relay server（Peer Relay）功能，为保留此功能而刻意不加（参见 issue [#161](https://github.com/GuNanOvO/openwrt-tailscale/issues/161)）
+  `ts_omit_relayserver` is intentionally **not** in this list: the tag removes the Relay server (Peer Relay) feature
 * 若需要完整功能，可移除部分 `ts_omit_*` 参数
   Remove some `ts_omit_*` flags if full functionality is required
 * 功能越完整，体积越大

--- a/package/tailscale/Makefile
+++ b/package/tailscale/Makefile
@@ -28,6 +28,8 @@ PKG_BUILD_FLAGS:=no-mips16
 GO_PKG:=tailscale.com/cmd/tailscaled
 GO_PKG_LDFLAGS:=-s -w -X 'tailscale.com/version.longStamp=$(PKG_VERSION)-$(PKG_RELEASE) (OpenWrt-UPX)'
 GO_PKG_LDFLAGS_X:=tailscale.com/version.shortStamp=$(PKG_VERSION)
+# Note: keep ts_omit_relayserver out of this list - it removes the Relay server
+# feature (Peer Relay). It was removed in 1.102.4-r2 after issue #161.
 GO_PKG_TAGS:=ts_include_cli,ts_omit_aws,ts_omit_bird,ts_omit_completion,ts_omit_kube,ts_omit_systray,ts_omit_taildrop,ts_omit_tap,ts_omit_tpm,ts_omit_capture,ts_omit_syspolicy,ts_omit_debugeventbus,ts_omit_webclient
 
 ifneq ($(filter mips64% riscv64% loongarch64%,$(ARCH)),)


### PR DESCRIPTION
## 概要

同步 1.102.4-r2 的 `ts_omit_relayserver` 移除改动到所有相关文档。

### 变更

- **`.github/README.md` / `.github/README_en.md`**：编译优化章节的 TAGS 列表移除 `ts_omit_relayserver`；同步 Makefile 行号引用（TAGS L31→L33，UPX L65-74→L67-76）
- **`package/tailscale/FORK.md`**：TAGS 列表同步；新增说明——`ts_omit_relayserver` 刻意不加入列表（会移除 Relay server / Peer Relay 功能，参见 #161）
- **`package/tailscale/Makefile`**：`GO_PKG_TAGS` 上方增加防回归注释，说明不要把 `ts_omit_relayserver` 加回来

### 说明

docs 站点（guide/introduction 等）中的功能裁剪概述不含 relayserver，无需变更。